### PR TITLE
Hack for client side regeneration, closes #2721

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
@@ -94,7 +94,9 @@ class StartGamePacket extends DataPacket{
 	/** @var bool */
 	public $isTexturePacksRequired = true;
 	/** @var array */
-	public $gameRules = []; //TODO: implement this
+	public $gameRules = [ //TODO: implement this
+		"naturalregeneration" => [1, false] //Hack for client side regeneration
+	];
 	/** @var bool */
 	public $hasBonusChestEnabled = false;
 	/** @var bool */


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Regeneration when canceled can appear to regeneration, which isn't right. This PR adds a gamerule hack that prevents the client from making those false hearts appear. Discussed in the [issue](https://github.com/pmmp/PocketMine-MP/issues/2721), it has also been reported to mojang [here](https://bugs.mojang.com/browse/MCPE-20507)
### Relevant issues
<!-- List relevant issues here -->
Fixes #2721

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No API changes.
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No Behavioral (you're welcome for no "u" Dylan ❤️) changes.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Nothing is broken out of this.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
This was tested on a server with regeneration canceled and on a server with regeneration enabled. Both work as expected.